### PR TITLE
Added firefox specific mandatory manifest property

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,9 +2,15 @@
   "manifest_version": 3,
   "name": "Karaktersnitt for Studentweb",
   "short_name": "Karaktersnitt",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Regner automatisk ut karaktersnitt på Studentweb.",
   "homepage_url": "https://github.com/runarmod/Karaktersnitt",
+
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "{ed445e9e-ee55-4a38-9692-83a6012845d0}"
+    }
+  },
 
   "developer": {
     "name": "Runar Saur Modahl",


### PR DESCRIPTION
Firefox needs the ID of the extension when using manifest version 3. This has now been added as a browser specific setting