### PR TITLE
Ignored unneeded files for build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Karaktersnitt for Studentweb
 
-<a href="https://chromewebstore.google.com/detail/karaktersnitt-for-student/cnfbclbahglengpahopaafpoffahojhd"><img src="https://storage.googleapis.com/web-dev-uploads/image/WlD8wC6g8khYWPJUsQceQkhXSlv1/iNEddTyWiMfLSwFD6qGq.png" style='height: 60px; margin-right: 10px;' alt="Avaliable in the Chrome Web Store" /></a>
-<a href="https://addons.mozilla.org/addon/karaktersnitt-for-studentweb"><img src='https://blog.mozilla.org/addons/files/2015/11/get-the-addon.png' alt='Get the add-on for Firefox' style='height: 60px;' /></a>
+[<img src="https://storage.googleapis.com/web-dev-uploads/image/WlD8wC6g8khYWPJUsQceQkhXSlv1/iNEddTyWiMfLSwFD6qGq.png" style='height: 60px; margin-right: 10px;' alt="Avaliable in the Chrome Web Store" />](https://chromewebstore.google.com/detail/karaktersnitt-for-student/cnfbclbahglengpahopaafpoffahojhd)
+
+[<img src='https://blog.mozilla.org/addons/files/2015/11/get-the-addon.png' alt='Get the add-on for Firefox' style='height: 60px;' />](https://addons.mozilla.org/addon/karaktersnitt-for-studentweb)
 
 ## Beskrivelse
 
@@ -35,6 +36,9 @@ npm install --global web-ext
 
 # Run development which reloads on file changes
 web-ext run
+
+# Check for errors/notices/warnings
+web-ext lint
 
 # Build for production
 web-ext build

--- a/web-ext-config.js
+++ b/web-ext-config.js
@@ -1,0 +1,5 @@
+// Ignore files which does not need to be in the built package to reduce the size of the package.
+
+module.exports = {
+  ignoreFiles: ["config.js", "assets/image.png", "README.md"],
+};


### PR DESCRIPTION
This pull request makes the build size smaller by not including an image that is used in the README-file (along with the README and the config-file itself).

Closes #13 