### PR TITLE
GitHub Action: create release on new tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Create release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🔄 Checkout
+        uses: actions/checkout@v4
+
+      - name: 🟢 Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "latest"
+
+      - name: ⚙️ Install web-ext
+        run: npm install -g web-ext
+
+      - name: 🏗️ Build the extension
+        run: web-ext build
+
+      - name: 🚀 Release
+        uses: softprops/action-gh-release@v2
+        with:
+          token: ${{ secrets.TOKEN }}
+          generate_release_notes: true
+          make_latest: true
+          files: web-ext-artifacts/*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
   release:
     # prevents this action from running on forks
     if: github.repository == 'runarmod/Karaktersnitt'
+    name: Create new GitHub release
     runs-on: ubuntu-latest
     steps:
       - name: 🔄 Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,9 @@ on:
       - "v*.*.*"
 
 jobs:
-  build:
+  release:
+    # prevents this action from running on forks
+    if: github.repository == 'runarmod/Karaktersnitt'
     runs-on: ubuntu-latest
     steps:
       - name: 🔄 Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.zip
+web-ext-artifacts/
+.env

--- a/web-ext-config.mjs
+++ b/web-ext-config.mjs
@@ -1,5 +1,3 @@
 // Ignore files which does not need to be in the built package to reduce the size of the package.
 
-module.exports = {
-  ignoreFiles: ["config.js", "assets/example_grades.png", "README.md"],
-};
+export const ignoreFiles = ["config.js", "assets/example_grades.png", "README.md", ".env"];


### PR DESCRIPTION
These changes will make a GitHub Action run when a new tag is made (e.g. `v1.0.6`). This action builds the project (with `web-ext`) and creates a new release with a changelog and the packaged add-on as an asset.

Fixes #20 