### PR TITLE
Add abbr tag to indicate more info on the grade average

### DIFF
--- a/src/karaktersnitt_kalkulator.js
+++ b/src/karaktersnitt_kalkulator.js
@@ -15,7 +15,7 @@ document.getElementById("mineResultaterTittel").innerHTML = `
   <summary>Resultater - klikk for å se snitt</summary>
   <h2>
     <div>
-      Snittet ditt er <b id="snitt">BLANK</b> (<b id="snittBokstav">-</b>).
+      Snittet ditt er <b><abbr id="snitt">BLANK</abbr></b> (<b id="snittBokstav">-</b>).
       <br />
       Du har <b id="antallEmner">BLANK</b> <span id="emnerOrd">emner</span> som
       teller i snittet.


### PR DESCRIPTION
Now the grade average is inside a `abbr`-tag (in addition to `b`-tag), such that the user sees a dotted underline.

This will make it easier to see that more info (here the "exact" grade) will be visible if the grade average is hovered.

Closes #50 