### PR TITLE
Use version type when upgrading version

### DIFF
--- a/.github/scripts/version-upgrade.py
+++ b/.github/scripts/version-upgrade.py
@@ -2,40 +2,40 @@ import os
 import re
 import sys
 
-if len(sys.argv) < 2 or not re.match(r"^\d+\.\d+\.\d+$", sys.argv[1]):
-    print("Usage: python version-upgrade.py <version>")
-    print("Example: python version-upgrade.py 1.1.0")
-    print("(Note: format must be x.y.z where x, y, z are integers)")
-    sys.exit(1)
-
-manifest = os.path.join(os.path.dirname(__file__), "..", "..", "manifest.json")
+ROOT_DIR = os.path.join(os.path.dirname(__file__), "..", "..")
+manifest = os.path.join(ROOT_DIR, "manifest.json")
 
 with open(manifest, encoding="utf-8") as f:
     data = f.read()
 
-old_version = re.search(r'"version":\s*"(\d+\.\d+\.\d+)"', data).group(1)
+_match = re.search(r'"version":\s*"(\d+\.\d+\.\d+)"', data)
+if not _match:
+    print("Version not found in manifest.json")
+    sys.exit(1)
+
+old_version = _match.group(1)
 
 old_version_parts = tuple(map(int, old_version.split(".")))
-new_version_parts = tuple(map(int, sys.argv[1].split(".")))
 
 # Legal new versions, in order of patch, minor, major
-new_legal_versions = [
-    (old_version_parts[0], old_version_parts[1], old_version_parts[2] + 1),
-    (old_version_parts[0], old_version_parts[1] + 1, 0),
-    (old_version_parts[0] + 1, 0, 0),
-]
+LEGAL_VERSIONS = {
+    "patch": (old_version_parts[0], old_version_parts[1], old_version_parts[2] + 1),
+    "minor": (old_version_parts[0], old_version_parts[1] + 1, 0),
+    "major": (old_version_parts[0] + 1, 0, 0),
+}
 
-if new_version_parts not in new_legal_versions:
-    print("Invalid version number.")
-    print("Legal versions are:")
-    print("    Patch -", ".".join(map(str, new_legal_versions[0])))
-    print("    Minor -", ".".join(map(str, new_legal_versions[1])))
-    print("    Major -", ".".join(map(str, new_legal_versions[2])))
+if len(sys.argv) < 2 or sys.argv[1] not in LEGAL_VERSIONS:
+    print("Usage: python version-upgrade.py <patch|minor|major>")
+    print("Example: python version-upgrade.py minor")
     sys.exit(1)
+
+VERSION_UPGRADE_TYPE = sys.argv[1]
+
+NEW_VERSION = '.'.join(map(str, LEGAL_VERSIONS[VERSION_UPGRADE_TYPE]))
 
 new_data = re.sub(
     r'"version":\s*"\d+\.\d+\.\d+"',
-    f'"version": "{sys.argv[1]}"',
+    f'"version": "{NEW_VERSION}"',
     data,
     flags=re.MULTILINE,
 )
@@ -51,4 +51,5 @@ except Exception as e:
     print(f"An error occurred while writing the file: {e}")
     sys.exit(1)
 
-print(f"Version upgraded from {old_version} to {sys.argv[1]}")
+print(f"{VERSION_UPGRADE_TYPE.capitalize()} version upgrade successful.")
+print(f"Upgraded from {old_version} to {NEW_VERSION}")

--- a/.github/workflows/version-upgrade.yml
+++ b/.github/workflows/version-upgrade.yml
@@ -3,9 +3,14 @@ name: Upgrade version
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: "Version to upgrade to (e.g. '1.1.2')"
+      version_type:
+        type: choice
+        description: "Version bump type"
         required: true
+        options:
+          - "patch"
+          - "minor"
+          - "major"
 
 jobs:
   upgrade:
@@ -23,11 +28,20 @@ jobs:
           python-version: "3.12"
 
       - name: 📦 Upgrade version
-        run: python version-upgrade.py ${{ github.event.inputs.version }}
+        run: python version-upgrade.py ${{ github.event.inputs.version_type }}
         working-directory: .github/scripts
+
+      - name: 🏷️ Extract new version number
+        id: version_extraction
+        run: |
+          NEW_VERSION=$(grep '"version":' manifest.json | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+")
+          echo "NEW_VERSION=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "New version: $NEW_VERSION"
 
       - name: 🤖 Commit and push
         uses: stefanzweifel/git-auto-commit-action@v5
+        env:
+          NEW_VERSION: ${{ steps.version_extraction.outputs.NEW_VERSION }}
         with:
-          commit_message: Upgrade to version ${{ github.event.inputs.version }}
-          tagging_message: "v${{ github.event.inputs.version }}"
+          commit_message: Upgrade to version ${{ env.NEW_VERSION }}
+          tagging_message: "v${{ env.NEW_VERSION }}"


### PR DESCRIPTION
Using version type (patch/minor/major) makes it more difficult to do any mistakes when upgrading version on GitHub. Before this change, the user has to write the new version-number, which is more error prone, as he/she has to know what the previous version exactly is.

Closes #46 
See #44 