### PR TITLE
Ignore unneeded files from build

### DIFF
--- a/web-ext-config.mjs
+++ b/web-ext-config.mjs
@@ -1,3 +1,9 @@
 // Ignore files which does not need to be in the built package to reduce the size of the package.
 
-export const ignoreFiles = ["config.js", "assets/example_grades.png", "README.md", ".env"];
+export const ignoreFiles = [
+  "config.js",
+  "assets/example_*.png",
+  "asserts/icon.svg",
+  "README.md",
+  ".env",
+];


### PR DESCRIPTION
In the v1.3.0 release, `assets/example_extra_grade.png` was accidentaly included in the built package, making the zip 192kB instead of 20kB.