### PR TITLE
Fix disappearing checkboxes and separators

### DIFF
--- a/src/karaktersnitt_kalkulator.js
+++ b/src/karaktersnitt_kalkulator.js
@@ -165,7 +165,7 @@ const changeButtonsTds = getElementsInsideElement(
 );
 
 const changeButtonsLabels = Array.from(changeButtonsTds).map((td) =>
-  getFirstElementInsideElement(td, "label", "tag")
+  getFirstElementInsideElement(td, "input", "tag")
 );
 
 const DELAY_MS = 300;


### PR DESCRIPTION
Change eventlistener from being on the labels, to them being on the buttons (this way, in effect the labels will also 'be listened to').

See linked issue for more context.

Fixes #69 